### PR TITLE
Upgrading phpstan & infection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
     "require-dev": {
         "ciaranmcnulty/phpspec-typehintedmethods": "^3.0",
         "friendsofphp/php-cs-fixer": "dev-long-line-fixers2",
-        "infection/infection": "^0.8.1",
+        "infection/infection": "^0.9@dev",
         "mockery/mockery": "^1.0",
         "phing/phing": "^2.16",
         "phpmd/phpmd": "^2.6",
         "phpspec/phpspec": "^4.2",
-        "phpstan/phpstan": "^0.9.0",
-        "phpstan/phpstan-phpunit": "^0.9.0",
+        "phpstan/phpstan": "^0.10.0",
+        "phpstan/phpstan-phpunit": "^0.10.0",
         "phpunit/phpunit": "^7.0",
         "slevomat/coding-standard": "^4.0",
         "squizlabs/php_codesniffer": "^3.1"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,7 @@ parameters:
 	    - '#Call to an undefined static method DevboardLib\\GitHub\\PullRequest\\PullRequestState\:\:OPEN\(\).#'
 	    - '#Call to an undefined static method DevboardLib\\GitHub\\PullRequestReview\\PullRequestReviewAuthorAssociation::.#'
 	    - '#Property DevboardLib\\GitHubWebhook\\HookFactory\\Push\\PushEventFactory\:\:\$factories#'
+	    - '#Parameter \#1 \$json of function json_decode expects string, string|false given.#'
 	includes:
 	    - vendor/phpstan/phpstan-phpunit/extension.neon
 	    - vendor/phpstan/phpstan-phpunit/rules.neon

--- a/src/CoreFactory/RepoTimestampsFactory.php
+++ b/src/CoreFactory/RepoTimestampsFactory.php
@@ -18,19 +18,19 @@ class RepoTimestampsFactory
     public function create(array $data): RepoTimestamps
     {
         if (is_numeric($data['created_at'])) {
-            $createdAt = new RepoCreatedAt(gmdate("Y-m-d\TH:i:s\Z", $data['created_at']));
+            $createdAt = new RepoCreatedAt(gmdate("Y-m-d\TH:i:s\Z", (int) $data['created_at']));
         } else {
             $createdAt = new RepoCreatedAt($data['created_at']);
         }
 
         if (is_numeric($data['updated_at'])) {
-            $updatedAt = new RepoUpdatedAt(gmdate("Y-m-d\TH:i:s\Z", $data['updated_at']));
+            $updatedAt = new RepoUpdatedAt(gmdate("Y-m-d\TH:i:s\Z", (int) $data['updated_at']));
         } else {
             $updatedAt = new RepoUpdatedAt($data['updated_at']);
         }
 
         if (is_numeric($data['pushed_at'])) {
-            $pushedAt = new RepoPushedAt(gmdate("Y-m-d\TH:i:s\Z", $data['pushed_at']));
+            $pushedAt = new RepoPushedAt(gmdate("Y-m-d\TH:i:s\Z", (int) $data['pushed_at']));
         } else {
             $pushedAt = new RepoPushedAt($data['pushed_at']);
         }


### PR DESCRIPTION
Phpstan 0.10 is out and since it uses nikic/php-parser 4.x, we need to upgrade infection to 0.9 dev version too.